### PR TITLE
Allow user to put PASE executable in a different directory than /usr/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+BINDIR=/usr/bin
 LIBRARY=iService
 DBGVIEW=*ALL
 
@@ -95,11 +96,11 @@ Main.pgm: Main.module
 	system -q "CRTPGM ACTGRP(*CALLER) PGM($(LIBRARY)/$(@:%.pgm=%)) MODULE($(^:%.module=$(LIBRARY)/%)) BNDSRVPGM($(LIBRARY)/Storedp)" && touch $@
 
 pase.pgm: src/pase/iService.c
-	gcc -g $^ -o /usr/bin/$(LIBRARY) && touch $@
-	chmod 777 /usr/bin/$(LIBRARY) && touch $@
+	gcc -g $^ -o $(BINDIR)/$(LIBRARY) && touch $@
+	chmod 777 $(BINDIR)/$(LIBRARY) && touch $@
 
 clean: DropStoredp.sqluninst
-	rm -f *.pgm *.srvpgm *.module *.lib *.sqlinst *.srcpf *.sql /usr/bin/$(LIBRARY) src/Config.h
+	rm -f *.pgm *.srvpgm *.module *.lib *.sqlinst *.srcpf *.sql $(BINDIR)/$(LIBRARY) src/Config.h
 	system -q 'CLRLIB $(LIBRARY)' || :
 	system -q 'DLTLIB $(LIBRARY)' || :
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ make
 
 OR
 
-make LIBRARY=yourlib DBGVIEW=*ALL
+make LIBRARY=yourlib DBGVIEW=*ALL BINDIR=your_ifs_bin_directory
 
 ```
 ## Security Consideration


### PR DESCRIPTION
If you don't have write permission to /usr/bin the build fails. This minor change to the Makefile allows you to put your PASE executable somewhere else for development & testing.